### PR TITLE
Fix msdfgen paths.

### DIFF
--- a/Merlin/Scripts/MSDFAtlasGenerator.cs
+++ b/Merlin/Scripts/MSDFAtlasGenerator.cs
@@ -38,8 +38,8 @@ public class MSDFAtlasGenerator : EditorWindow
     public Texture2D AtlasToSave = null;
     public bool UseTextureCompression = false;
 
-    private const string MSDFGenPath = "Assets/Merlin/MSDF/bin/msdfgen.exe";
-    private const string MSDFTempPath = "Assets/Merlin/MSDF/gen/glyph{0}.png";
+    private const string MSDFGenPath = "Assets/Merlin/bin/msdfgen.exe";
+    private const string MSDFTempPath = "Assets/Merlin/gen/glyph{0}.png";
 
     [MenuItem("Window/Merlin/MSDF Font Generator")]
     public static void ShowWindow()

--- a/Merlin/Scripts/MSDFTilesetGenerator.cs
+++ b/Merlin/Scripts/MSDFTilesetGenerator.cs
@@ -41,8 +41,8 @@ public class MSDFTilesetGenerator : EditorWindow
     public bool IncludeAllGlyphs = false;
     public bool UseTextureCompression = false;
 
-    private const string MSDFGenPath = "Assets/Merlin/MSDF/bin/msdfgen.exe";
-    private const string MSDFTempPath = "Assets/Merlin/MSDF/gen/glyph{0}.png";
+    private const string MSDFGenPath = "Assets/Merlin/bin/msdfgen.exe";
+    private const string MSDFTempPath = "Assets/Merlin/gen/glyph{0}.png";
 
     [MenuItem("Window/Merlin/MSDF Font Tileset Generator")]
     public static void ShowWindow()


### PR DESCRIPTION
Tool is broken because the path to msdfgen.exe is incorrect within the script. 
Assuming the included msdfgen.exe was last minute for redistribution and the script wasn't edited..?

Anyways PR just removes those smol text.
![image](https://user-images.githubusercontent.com/37721153/173181304-fb18a0ff-5012-4860-a7a5-d124cfa6222c.png)
 